### PR TITLE
Add the opportunity to extend return value from query

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,44 @@ $slideshow.observe(complexSetup);
 ```
 
 Using `$.maybe`, if the element is not found, any downstream code is skipped, without needing to check for the element's existence using a conditional.
+
+### Extending unknot
+
+The unknot query object can be extended with additional functions by supplying a `member` parameter when creating the query function. Additional functions must take the form of a function that accepts a stream of elements as the only argument, and returns the function that will be added to the return value of the unknot query.
+
+For example, if you wanted to add a function "`data`" for reading `dataList` attributes, it could be added like this:
+
+```javascript
+const $ = unknot(loaded, {
+  member: {
+    data: element => name => element.map(e => e.dataList[name])
+  }
+});
+
+// Given: <div class="foo" data-bar="baz"></div>
+const $foo = $(".foo");
+const bar = $foo.data("bar");
+
+bar.log();
+// <value> "baz"
+```
+
+Setting values can also be added the same way. A function for setting the text of an element could be implemented like this:
+
+```javascript
+import { Kefir as K } from "kefir";
+
+const $ = unknot(loaded, {
+  member: {
+    text: element => text =>
+      K.combine([element, text]).observe(([e, t]) => {
+        e.innerText = t;
+      })
+  }
+});
+
+const $foo = $(".foo");
+const countdown = K.sequentially(1000, [3, 2, 1, "Go!"]);
+
+$foo.text(countdown);
+```

--- a/build/index.js
+++ b/build/index.js
@@ -46,9 +46,11 @@ var queryMaybeBy = function queryMaybeBy(sample, finder, selector) {
   }).flatMap(domResult).toProperty();
 };
 
-var merge = function merge(element, functions) {
-  Object.keys(functions).forEach(function (name) {
-    element[name] = functions[name](element);
+var reduceFunctionSets = function reduceFunctionSets(element, sets) {
+  sets.forEach(function (functions) {
+    Object.keys(functions).forEach(function (name) {
+      element[name] = functions[name](element);
+    });
   });
 
   return element;
@@ -57,12 +59,14 @@ var merge = function merge(element, functions) {
 function unknot(sample) {
   var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
       _ref$one = _ref.one,
-      one = _ref$one === undefined ? _qPrime.queryOne : _ref$one;
+      one = _ref$one === undefined ? _qPrime.queryOne : _ref$one,
+      _ref$member = _ref.member,
+      member = _ref$member === undefined ? {} : _ref$member;
 
   var domMaybe = function domMaybe(selector) {
     var element = queryMaybeBy(sample, one, selector);
 
-    return merge(element, DEFAULT_FUNCTIONS);
+    return reduceFunctionSets(element, [DEFAULT_FUNCTIONS, member]);
   };
 
   var dom = function dom(selector) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,19 +23,21 @@ const queryMaybeBy = (sample, finder, selector) =>
     .flatMap(domResult)
     .toProperty();
 
-const merge = (element, functions) => {
-  Object.keys(functions).forEach(name => {
-    element[name] = functions[name](element);
+const reduceFunctionSets = (element, sets) => {
+  sets.forEach(functions => {
+    Object.keys(functions).forEach(name => {
+      element[name] = functions[name](element);
+    });
   });
 
   return element;
 };
 
-export default function unknot(sample, { one = queryOne } = {}) {
+export default function unknot(sample, { one = queryOne, member = {} } = {}) {
   const domMaybe = selector => {
     const element = queryMaybeBy(sample, one, selector);
 
-    return merge(element, DEFAULT_FUNCTIONS);
+    return reduceFunctionSets(element, [DEFAULT_FUNCTIONS, member]);
   };
 
   const dom = selector => {

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,21 @@ test("exposes a className function", t => {
   t.end();
 });
 
+test("extends returned stream with member functions", t => {
+  const $ = unknot(K.never(), {
+    member: {
+      bar: () => () => null,
+      foo: element => () => element
+    }
+  });
+  const element = $(".asdf");
+
+  t.assert("bar" in element);
+  t.assert("foo" in element);
+  t.equal(element, element.foo());
+  t.end();
+});
+
 test("throws when element is not present", t => {
   const $ = unknot(K.constant(true), {
     one: () => undefined


### PR DESCRIPTION
In regards to #2, this adds a configuration option for adding extra functionality to the object returned by an `unknot` query. Currently, that looks like this:

```javascript
const $ = unknot(loaded, {
  member: {
    bar: element => (arg1, arg2) => element.map(() => // ... do something)
  }
});

const $foo = $(".foo");

// `bar` is available to call on the returned object...
$foo.bar(1, 2);
```

I chose `member` as the name for the configuration option, to leave open both the opportunity for other configuration options, but also thinking about how to handle the same kind of configuration for handling queries that return collections of elements. I'm specifically thinking that there might want to be both `member` and `list` functions that are exposed (though currently collection/list queries aren't supported).

Not completely happy with this, but I couldn't think of another term that would satisfy both requirements.